### PR TITLE
Removed old Id tags

### DIFF
--- a/XSC/SemanticGraph/Graph.tpp
+++ b/XSC/SemanticGraph/Graph.tpp
@@ -1,7 +1,6 @@
 // -*- C++ -*-
 // file      : XSC/SemanticGraph/Graph.tpp
 // author    : Boris Kolpackov <boris@dre.vanderbilt.edu>
-// cvs-id    : $Id$
 
 namespace XSC
 {

--- a/XSC/Traversal/Elements.tpp
+++ b/XSC/Traversal/Elements.tpp
@@ -1,6 +1,5 @@
 // file      : XSC/Traversal/Elements.tpp
 // author    : Boris Kolpackov <boris@dre.vanderbilt.edu>
-// cvs-id    : $Id$
 
 #ifndef XSC_ELEMENTS_TPP
 #define XSC_ELEMENTS_TPP

--- a/XSCRT/XMLSchema/Traversal.tpp
+++ b/XSCRT/XMLSchema/Traversal.tpp
@@ -1,11 +1,10 @@
 // file      : XMLSchema/Traversal.tpp
 // author    : Boris Kolpackov <boris@dre.vanderbilt.edu>
-// cvs-id    : $Id$
 
 namespace XMLSchema
 {
   namespace Traversal
   {
-    
+
   }
 }

--- a/XSCRT/XMLSchema/TypeInfo.tpp
+++ b/XSCRT/XMLSchema/TypeInfo.tpp
@@ -1,6 +1,5 @@
 // file      : XMLSchema/TypeInfo.tpp
 // author    : Boris Kolpackov <boris@dre.vanderbilt.edu>
-// cvs-id    : $Id$
 
 namespace XMLSchema
 {

--- a/XSCRT/XMLSchema/Types.tpp
+++ b/XSCRT/XMLSchema/Types.tpp
@@ -1,9 +1,8 @@
 // file      : XMLSchema/Types.tpp
 // author    : Boris Kolpackov <boris@dre.vanderbilt.edu>
-// cvs-id    : $Id$
 
 namespace XMLSchema
 {
-  
+
 }
 

--- a/XSCRT/XMLSchema/Writer.tpp
+++ b/XSCRT/XMLSchema/Writer.tpp
@@ -1,6 +1,5 @@
 // file      : XMLSchema/Writer.tpp
 // author    : Boris Kolpackov <boris@dre.vanderbilt.edu>
-// cvs-id    : $Id$
 
 namespace XMLSchema
 {

--- a/XSCRT/XSCRT/Elements.tpp
+++ b/XSCRT/XSCRT/Elements.tpp
@@ -1,6 +1,5 @@
 // file      : XSC/Elements.tpp
 // author    : Boris Kolpackov <boris@dre.vanderbilt.edu>
-// cvs-id    : $Id$
 
 namespace XSC
 {

--- a/XSCRT/XSCRT/Parser.tpp
+++ b/XSCRT/XSCRT/Parser.tpp
@@ -1,6 +1,5 @@
 // file      : XSCRT/Parser.tpp
 // author    : Boris Kolpackov <boris@dre.vanderbilt.edu>
-// cvs-id    : $Id$
 
 namespace XSCRT
 {

--- a/XSCRT/XSCRT/Traversal.tpp
+++ b/XSCRT/XSCRT/Traversal.tpp
@@ -1,6 +1,5 @@
 // file       : XSCRT/Traversal.txx
 // author     : Boris Kolpackov <boris@dre.vanderbilt.edu>
-// cvs-id     : $Id$
 
 namespace  XSCRT
 {

--- a/XSCRT/XSCRT/Writer.tpp
+++ b/XSCRT/XSCRT/Writer.tpp
@@ -1,6 +1,5 @@
 // file      : XSCRT/Writer.tpp
 // author    : Boris Kolpackov <boris@dre.vanderbilt.edu>
-// cvs-id    : $Id$
 
 namespace XSCRT
 {

--- a/XSCRT/XSCRT/XML.tpp
+++ b/XSCRT/XSCRT/XML.tpp
@@ -1,6 +1,5 @@
 // file      : XSCRT/XML.tpp
 // author    : Boris Kolpackov <boris@dre.vanderbilt.edu>
-// cvs-id    : $Id$
 
 namespace XSCRT
 {

--- a/contrib/CCF/CCF/CCF/CIDL/Traversal/Composition.tpp
+++ b/contrib/CCF/CCF/CCF/CIDL/Traversal/Composition.tpp
@@ -1,6 +1,5 @@
 // file      : CCF/CIDL/Traversal/Composition.tpp
 // author    : Boris Kolpackov <boris@dre.vanderbilt.edu>
-// cvs-id    : $Id$
 
 namespace CCF
 {

--- a/contrib/CCF/CCF/CCF/IDL2/SemanticAction/Impl/Elements.tpp
+++ b/contrib/CCF/CCF/CCF/IDL2/SemanticAction/Impl/Elements.tpp
@@ -1,6 +1,5 @@
 // file      : CCF/IDL2/SemanticAction/Impl/Elements.cpp
 // author    : Boris Kolpackov <boris@dre.vanderbilt.edu>
-// cvs-id    : $Id$
 
 namespace CCF
 {

--- a/contrib/CCF/CCF/CCF/IDL2/SemanticGraph/Elements.tpp
+++ b/contrib/CCF/CCF/CCF/IDL2/SemanticGraph/Elements.tpp
@@ -1,6 +1,5 @@
 // file      : CCF/IDL2/SemanticGraph/Elements.tpp
 // author    : Boris Kolpackov <boris@dre.vanderbilt.edu>
-// cvs-id    : $Id$
 
 namespace CCF
 {

--- a/contrib/CCF/CCF/CCF/IDL2/SemanticGraph/Graph.tpp
+++ b/contrib/CCF/CCF/CCF/IDL2/SemanticGraph/Graph.tpp
@@ -1,6 +1,5 @@
 // file      : CCF/IDL2/SemanticGraph/Graph.tpp
 // author    : Boris Kolpackov <boris@dre.vanderbilt.edu>
-// cvs-id    : $Id$
 
 namespace CCF
 {

--- a/contrib/CCF/CCF/CCF/IDL2/Traversal/Elements.tpp
+++ b/contrib/CCF/CCF/CCF/IDL2/Traversal/Elements.tpp
@@ -1,6 +1,5 @@
 // file      : CCF/IDL2/Traversal/Elements.tpp
 // author    : Boris Kolpackov <boris@dre.vanderbilt.edu>
-// cvs-id    : $Id$
 
 #include <iostream>
 

--- a/contrib/CCF/CCF/CCF/IDL2/Traversal/Interface.tpp
+++ b/contrib/CCF/CCF/CCF/IDL2/Traversal/Interface.tpp
@@ -1,6 +1,5 @@
 // file      : CCF/IDL2/Traversal/Interface.tpp
 // author    : Boris Kolpackov <boris@dre.vanderbilt.edu>
-// cvs-id    : $Id$
 
 namespace CCF
 {

--- a/contrib/CCF/CCF/CCF/IDL2/Traversal/Operation.tpp
+++ b/contrib/CCF/CCF/CCF/IDL2/Traversal/Operation.tpp
@@ -1,6 +1,5 @@
 // file      : CCF/IDL2/Traversal/Operation.tpp
 // author    : Boris Kolpackov <boris@dre.vanderbilt.edu>
-// cvs-id    : $Id$
 
 namespace CCF
 {

--- a/contrib/CCF/CCF/CCF/IDL2/Traversal/ValueType.tpp
+++ b/contrib/CCF/CCF/CCF/IDL2/Traversal/ValueType.tpp
@@ -1,6 +1,5 @@
 // file      : CCF/IDL2/Traversal/ValueType.tpp
 // author    : Boris Kolpackov <boris@dre.vanderbilt.edu>
-// cvs-id    : $Id$
 
 namespace CCF
 {

--- a/contrib/CCF/CCF/CCF/IDL2/Traversal/ValueTypeMember.tpp
+++ b/contrib/CCF/CCF/CCF/IDL2/Traversal/ValueTypeMember.tpp
@@ -1,6 +1,5 @@
 // file      : CCF/IDL2/Traversal/ValueTypeMember.tpp
 // author    : Boris Kolpackov <boris@dre.vanderbilt.edu>
-// cvs-id    : $Id$
 
 namespace CCF
 {

--- a/contrib/CCF/CCF/CCF/IDL3/Traversal/Component.tpp
+++ b/contrib/CCF/CCF/CCF/IDL3/Traversal/Component.tpp
@@ -1,6 +1,5 @@
 // file      : CCF/IDL3/Traversal/Component.tpp
 // author    : Boris Kolpackov <boris@dre.vanderbilt.edu>
-// cvs-id    : $Id$
 
 namespace CCF
 {

--- a/contrib/CCF/CCF/CCF/IDL3/Traversal/EventType.tpp
+++ b/contrib/CCF/CCF/CCF/IDL3/Traversal/EventType.tpp
@@ -1,6 +1,5 @@
 // file      : CCF/IDL3/Traversal/EventType.tpp
 // author    : Boris Kolpackov <boris@dre.vanderbilt.edu>
-// cvs-id    : $Id$
 
 namespace CCF
 {

--- a/contrib/CCF/utility/Utility/ExH/Compound.tpp
+++ b/contrib/CCF/utility/Utility/ExH/Compound.tpp
@@ -71,4 +71,3 @@ namespace Utility
     }
   }
 }
-//$Id$

--- a/contrib/CCF/utility/Utility/ExH/Converter.tpp
+++ b/contrib/CCF/utility/Utility/ExH/Converter.tpp
@@ -16,4 +16,3 @@ namespace Utility
     }
   }
 }
-//$Id$

--- a/contrib/CCF/utility/Utility/ExH/Logic/DescriptiveException.tpp
+++ b/contrib/CCF/utility/Utility/ExH/Logic/DescriptiveException.tpp
@@ -20,4 +20,3 @@ namespace Utility
     }
   }
 }
-//$Id$

--- a/contrib/CCF/utility/Utility/ExH/System/DescriptiveException.tpp
+++ b/contrib/CCF/utility/Utility/ExH/System/DescriptiveException.tpp
@@ -20,4 +20,3 @@ namespace Utility
     }
   }
 }
-//$Id$

--- a/contrib/CCF/utility/Utility/Introspection/TypeId.tpp
+++ b/contrib/CCF/utility/Utility/Introspection/TypeId.tpp
@@ -15,4 +15,3 @@ namespace Utility
     }
   }
 }
-//$Id$

--- a/contrib/CCF/utility/Utility/ReferenceCounting/Interface.tpp
+++ b/contrib/CCF/utility/Utility/ReferenceCounting/Interface.tpp
@@ -16,4 +16,3 @@ namespace Utility
     }
   }
 }
-//$Id$

--- a/contrib/CCF/utility/Utility/ReferenceCounting/SmartPtr.tpp
+++ b/contrib/CCF/utility/Utility/ReferenceCounting/SmartPtr.tpp
@@ -161,4 +161,3 @@ namespace Utility
     }
   }
 }
-//$Id$

--- a/contrib/CCF/utility/Utility/ReferenceCounting/StrictPtr.tpp
+++ b/contrib/CCF/utility/Utility/ReferenceCounting/StrictPtr.tpp
@@ -158,4 +158,3 @@ namespace Utility
     }
   }
 }
-//$Id$

--- a/contrib/CCF/utility/Vault/hetero/map.tpp
+++ b/contrib/CCF/utility/Vault/hetero/map.tpp
@@ -9,4 +9,3 @@ namespace Utility
   {
   }
 }
-//$Id$


### PR DESCRIPTION
    * XSC/SemanticGraph/Graph.tpp:
    * XSC/Traversal/Elements.tpp:
    * XSCRT/XMLSchema/Traversal.tpp:
    * XSCRT/XMLSchema/TypeInfo.tpp:
    * XSCRT/XMLSchema/Types.tpp:
    * XSCRT/XMLSchema/Writer.tpp:
    * XSCRT/XSCRT/Elements.tpp:
    * XSCRT/XSCRT/Parser.tpp:
    * XSCRT/XSCRT/Traversal.tpp:
    * XSCRT/XSCRT/Writer.tpp:
    * XSCRT/XSCRT/XML.tpp:
    * contrib/CCF/CCF/CCF/CIDL/Traversal/Composition.tpp:
    * contrib/CCF/CCF/CCF/IDL2/SemanticAction/Impl/Elements.tpp:
    * contrib/CCF/CCF/CCF/IDL2/SemanticGraph/Elements.tpp:
    * contrib/CCF/CCF/CCF/IDL2/SemanticGraph/Graph.tpp:
    * contrib/CCF/CCF/CCF/IDL2/Traversal/Elements.tpp:
    * contrib/CCF/CCF/CCF/IDL2/Traversal/Interface.tpp:
    * contrib/CCF/CCF/CCF/IDL2/Traversal/Operation.tpp:
    * contrib/CCF/CCF/CCF/IDL2/Traversal/ValueType.tpp:
    * contrib/CCF/CCF/CCF/IDL2/Traversal/ValueTypeMember.tpp:
    * contrib/CCF/CCF/CCF/IDL3/Traversal/Component.tpp:
    * contrib/CCF/CCF/CCF/IDL3/Traversal/EventType.tpp:
    * contrib/CCF/utility/Utility/ExH/Compound.tpp:
    * contrib/CCF/utility/Utility/ExH/Converter.tpp:
    * contrib/CCF/utility/Utility/ExH/Logic/DescriptiveException.tpp:
    * contrib/CCF/utility/Utility/ExH/System/DescriptiveException.tpp:
    * contrib/CCF/utility/Utility/Introspection/TypeId.tpp:
    * contrib/CCF/utility/Utility/ReferenceCounting/Interface.tpp:
    * contrib/CCF/utility/Utility/ReferenceCounting/SmartPtr.tpp:
    * contrib/CCF/utility/Utility/ReferenceCounting/StrictPtr.tpp:
    * contrib/CCF/utility/Vault/hetero/map.tpp: