### PR TITLE
Generate ace/ace_wchar.h only when we have ACE_TCHAR as chartype

### DIFF
--- a/XSC/be/CXX/Header.cpp
+++ b/XSC/be/CXX/Header.cpp
@@ -907,7 +907,10 @@ generate_header (Context& ctx,
           << "#include \"ace/Null_Mutex.h\"" << endl;
   }
 
-  ctx.os << "#include \"ace/ace_wchar.h\"" << endl << endl;
+  if (ctx.char_type == L"ACE_TCHAR")
+  {
+    ctx.os << "#include \"ace/ace_wchar.h\"" << endl << endl;
+  }
 
   // -- Include CDR Type headers if cdr generation is
   // enabled

--- a/XSC/be/CXX/Inline.cpp
+++ b/XSC/be/CXX/Inline.cpp
@@ -1423,9 +1423,13 @@ namespace
 void
 generate_inline (Context& ctx, SemanticGraph::Schema& schema, bool i)
 {
+  if (ctx.char_type == L"ACE_TCHAR")
+  {
+    ctx.os << "#include \"ace/ace_wchar.h\"" << endl;
+  }
+
   ctx.os << "#include \"ace/Null_Mutex.h\"" << endl
      << "#include \"ace/TSS_T.h\""<< endl
-     << "#include \"ace/ace_wchar.h\"" << endl
      << "#include \"ace/Singleton.h\"" << endl << endl;
 
   Traversal::Schema traverser;

--- a/XSC/be/CXX/Source.cpp
+++ b/XSC/be/CXX/Source.cpp
@@ -8,7 +8,6 @@
 #include "XSC/Traversal.hpp"
 
 #include "CCF/CodeGenerationKit/Regex.hpp"
-//#include "ace/ace_wchar.h"
 
 #include <ctype.h>
 #include <string>


### PR DESCRIPTION
    * XSC/be/CXX/Header.cpp:
    * XSC/be/CXX/Inline.cpp:
    * XSC/be/CXX/Source.cpp: