### PR TITLE
Restructure cpp11 to CPPMODE wich can be 03/11/17

### DIFF
--- a/XSC/be/CXX/Elements.hpp
+++ b/XSC/be/CXX/Elements.hpp
@@ -24,6 +24,12 @@ typedef std::vector<string> NamespaceMapping;
 class Context
 {
 public:
+  // Which C++ version we generate for
+  enum class CPPMODE {
+    CPP03,
+    CPP11,
+    CPP17
+  };
 
 
 public:
@@ -61,7 +67,7 @@ public:
         ns_mapping_ (ns_mapping),
         cdr_reader_generation_ (false),
         cdr_writer_generation_ (false),
-        cpp11_ (false),
+        cppmode_ (CPPMODE::CPP03),
         generate_ra_sequences_ (false)
   {
     if (char_type == L"wchar_t")
@@ -107,7 +113,7 @@ protected:
         ns_mapping_ (c.ns_mapping_),
         cdr_reader_generation_ (c.cdr_reader_generation_),
         cdr_writer_generation_ (c.cdr_writer_generation_),
-        cpp11_ (c.cpp11_),
+        cppmode_ (c.cppmode_),
         generate_ra_sequences_ (c.generate_ra_sequences_)
   {
   }
@@ -218,9 +224,9 @@ public:
     this->cdr_writer_generation_ = flag;
   }
   void
-  cpp11 (bool flag)
+  cppmode (CPPMODE flag)
   {
-    this->cpp11_ = flag;
+    this->cppmode_ = flag;
   }
   bool
   cdr_reader_generation_enabled ()
@@ -232,10 +238,10 @@ public:
   {
     return this->cdr_writer_generation_;
   }
-  bool
-  cpp11 ()
+  CPPMODE
+  cppmode ()
   {
-    return this->cpp11_;
+    return this->cppmode_;
   }
 
   void
@@ -315,8 +321,9 @@ protected:
   bool cdr_reader_generation_;
   bool cdr_writer_generation_;
 
-  // Generate code depending on C++11 features
-  bool cpp11_;
+  // Generate code depending on C++ features
+  CPPMODE cppmode_;
+
   bool generate_ra_sequences_;
 };
 

--- a/XSC/be/CXX/Generator.cpp
+++ b/XSC/be/CXX/Generator.cpp
@@ -117,6 +117,8 @@ options (po::options_description& d)
      "CDR streams.")
     ("cxx-cpp11",
      "Generate code that depends on C++11 features.")
+    ("cxx-cpp17",
+     "Generate code that depends on C++17 features.")
     ;
 }
 
@@ -332,7 +334,16 @@ generate (po::variables_map const& vm, Schema& schema, fs::path const& file_path
   bool cdr_reader (vm.count ("cxx-generate-cdr-reader-types"));
   bool cdr_writer (vm.count ("cxx-generate-cdr-writer-types"));
 
-  bool cpp11 (vm.count ("cxx-cpp11"));
+  ::Context::CPPMODE cppmode_ { ::Context::CPPMODE::CPP03 };
+  if (vm.count ("cxx-cpp11"))
+    {
+      cppmode_ = ::Context::CPPMODE::CPP11;
+    }
+  if (vm.count ("cxx-cpp17"))
+    {
+      cppmode_ = ::Context::CPPMODE::CPP17;
+    }
+
 
   // Check about random access sequences
   bool ra_sequences (vm.count ("cxx-enable-random-access-sequences"));
@@ -413,7 +424,7 @@ generate (po::variables_map const& vm, Schema& schema, fs::path const& file_path
     ctx.cdr_reader_generation (cdr_reader);
     ctx.cdr_writer_generation (cdr_writer);
 
-    ctx.cpp11 (cpp11);
+    ctx.cppmode (cppmode_);
 
     // Add additional information to the context:
     ctx.generate_ra_sequences (ra_sequences);
@@ -455,7 +466,7 @@ generate (po::variables_map const& vm, Schema& schema, fs::path const& file_path
     ctx.cdr_reader_generation (cdr_reader);
     ctx.cdr_writer_generation (cdr_writer);
 
-    ctx.cpp11 (cpp11);
+    ctx.cppmode (cppmode_);
 
     // Add additional information to the context:
     ctx.generate_ra_sequences (ra_sequences);
@@ -479,7 +490,7 @@ generate (po::variables_map const& vm, Schema& schema, fs::path const& file_path
     // Add additional information to the context:
     ctx.generate_ra_sequences (ra_sequences);
 
-    ctx.cpp11 (cpp11);
+    ctx.cppmode (cppmode_);
 
     if (!inline_)
     {

--- a/XSC/be/CXX/Header.cpp
+++ b/XSC/be/CXX/Header.cpp
@@ -36,13 +36,15 @@ namespace
 
       os << " : public " << name
          << "{";
-      if (this->cpp11_)
+      switch(this->cppmode_)
       {
-        os << "using Base = " << name << ";" << endl;
-      }
-      else
-      {
-        os << "typedef " << name << " Base;" << endl;
+        case CPPMODE::CPP03:
+          os << "typedef " << name << " Base;" << endl;
+          break;
+        case CPPMODE::CPP11:
+        case CPPMODE::CPP17:
+          os << "using Base = " << name << ";" << endl;
+          break;
       }
     }
   };
@@ -176,45 +178,52 @@ namespace
       {
         // sequence
         //
-        if (this->cpp11_)
+        switch(this->cppmode_)
         {
-          os << "using " << name << "_container_type = " << container  << "< " << type << ">;";
+          case CPPMODE::CPP03:
+            os << "typedef ACE_Refcounted_Auto_Ptr < " << type << ", ACE_Null_Mutex> " << name << "_value_type;";
+            os << "typedef " << container  << "<" << name << "_value_type> " << name << "_container_type;";
+            break;
+          case CPPMODE::CPP11:
+          case CPPMODE::CPP17:
+            os << "using " << name << "_container_type = " << container  << "< " << type << ">;";
+            break;
         }
-        else
+        switch(this->cppmode_)
         {
-          os << "typedef ACE_Refcounted_Auto_Ptr < " << type << ", ACE_Null_Mutex> " << name << "_value_type;";
-          os << "typedef " << container  << "<" << name << "_value_type> " << name << "_container_type;";
-        }
-        if (this->cpp11_)
-        {
-          os << "using " << name << "_const_iterator = " << name << "_container_type::const_iterator;";
-        }
-        else
-        {
-          os << "typedef " << name << "_container_type::iterator " << name << "_iterator;";
-          os << "typedef " << name << "_container_type::const_iterator " << name << "_const_iterator;";
-          os << name << "_iterator begin_" << name << " ();";
-          os << name << "_iterator end_" << name << " ();";
+          case CPPMODE::CPP03:
+            os << "typedef " << name << "_container_type::iterator " << name << "_iterator;";
+            os << "typedef " << name << "_container_type::const_iterator " << name << "_const_iterator;";
+            os << name << "_iterator begin_" << name << " ();";
+            os << name << "_iterator end_" << name << " ();";
+            break;
+          case CPPMODE::CPP11:
+          case CPPMODE::CPP17:
+            os << "using " << name << "_const_iterator = " << name << "_container_type::const_iterator;";
+            break;
         }
 
         os << name << "_const_iterator begin_" << name << " () const;";
         os << name << "_const_iterator end_" << name << " () const;";
 
-        if (!this->cpp11_)
+        switch(this->cppmode_)
         {
-          os << "void add_" << name << " (" << name << "_value_type const&);";
-          os << "void del_" << name << " (" << name << "_value_type const&);";
+          case CPPMODE::CPP03:
+            os << "void add_" << name << " (" << name << "_value_type const&);";
+            os << "void del_" << name << " (" << name << "_value_type const&);";
+            break;
+          case CPPMODE::CPP11:
+          case CPPMODE::CPP17:
+            break;
         }
         //Return referenced item if an IDREF
-        if ((idref_ptr != std::string::npos) && (!this->cpp11_))
+        if ((idref_ptr != std::string::npos) && (this->cppmode_ == CPPMODE::CPP03))
         {
           os << "XSCRT::Type* get_" << name << "_ptr (const " << string_type <<"& idref);";
           os << "void set_" << name << "_ptr (const " << string_type << "& idref);";
         }
-        //if (!this->cpp11_)
-        {
-          os << "size_t count_" << name << " () const;";
-        }
+
+        os << "size_t count_" << name << " () const;";
 
         os << endl
            << "protected:" << endl;
@@ -231,7 +240,7 @@ namespace
         os << "void " << id (name) << " (" << type << " const& );";
 
         //Added for IDREF case
-        if ((idref_ptr != std::string::npos) && (!this->cpp11_))
+        if ((idref_ptr != std::string::npos) && (this->cppmode_ == CPPMODE::CPP03))
         {
            os << "::XSCRT::Type* get_" << id (name) << "_ptr ();\n";
            os << "void set_" << id (name) << "_ptr (const " << string_type << "& idref);";
@@ -239,15 +248,17 @@ namespace
 
         os << endl
            << "protected:" << endl;
-        if (this->cpp11_)
+        switch(this->cppmode_)
         {
-          os << "using " << id (name) << "_unique_ptr_type = std::unique_ptr< " << type << ">;";
-          os << id (name) << "_unique_ptr_type " << id (name) << "_;";
-        }
-        else
-        {
-          os << "typedef XML_XSC_SMART_PTR( " << type << ") " << id (name) << "_auto_ptr_type;";
-          os << id (name) << "_auto_ptr_type " << id (name) << "_;";
+          case CPPMODE::CPP03:
+            os << "typedef XML_XSC_SMART_PTR( " << type << ") " << id (name) << "_auto_ptr_type;";
+            os << id (name) << "_auto_ptr_type " << id (name) << "_;";
+            break;
+          case CPPMODE::CPP11:
+          case CPPMODE::CPP17:
+            os << "using " << id (name) << "_unique_ptr_type = std::unique_ptr< " << type << ">;";
+            os << id (name) << "_unique_ptr_type " << id (name) << "_;";
+            break;
         }
       }
       else
@@ -259,7 +270,7 @@ namespace
         os << "void " << id (name) << " (" << type << " const& );";
 
         //Added for IDREF case
-        if ((idref_ptr != std::string::npos) && (!this->cpp11_))
+        if ((idref_ptr != std::string::npos) && (this->cppmode_ == CPPMODE::CPP03))
         {
            os << "::XSCRT::Type* get_" << id (name) << "_ptr ( void );\n";
            os << "void set_" << id(name) << "_ptr (const " << string_type << "& idref);";
@@ -268,15 +279,17 @@ namespace
         os << endl
            << "protected:" << endl;
 
-        if (this->cpp11_)
+        switch(this->cppmode_)
         {
-          os << "using " << id (name) << "_unique_ptr_type = std::unique_ptr< " << type << ">;";
-          os << id (name) << "_unique_ptr_type " << id (name) << "_;";
-        }
-        else
-        {
-          os << "typedef XML_XSC_SMART_PTR( " << type << ") " << id (name) << "_auto_ptr_type;";
-          os << id (name) << "_auto_ptr_type " << id (name) << "_;";
+          case CPPMODE::CPP03:
+            os << "typedef XML_XSC_SMART_PTR( " << type << ") " << id (name) << "_auto_ptr_type;";
+            os << id (name) << "_auto_ptr_type " << id (name) << "_;";
+            break;
+          case CPPMODE::CPP11:
+          case CPPMODE::CPP17:
+            os << "using " << id (name) << "_unique_ptr_type = std::unique_ptr< " << type << ">;";
+            os << id (name) << "_unique_ptr_type " << id (name) << "_;";
+            break;
         }
       }
 
@@ -329,7 +342,7 @@ namespace
         os << "void " << id (name) << " (" << type << " const& );";
 
         //Added for IDREF case
-        if ((idref_ptr != std::string::npos) && (!this->cpp11_))
+        if ((idref_ptr != std::string::npos) && (this->cppmode_ == CPPMODE::CPP03))
         {
            os << "::XSCRT::Type* get_" << id (name) << "_ptr ();\n";
            os << "void set_" << id(name) << "_ptr (const " << string_type << "& idref);";
@@ -338,15 +351,17 @@ namespace
         os << endl
            << "protected:" << endl;
 
-        if (this->cpp11_)
+        switch(this->cppmode_)
         {
-          os << "using " << id (name) << "_unique_ptr_type = std::unique_ptr< " << type << ">;";
-          os << id (name) << "_unique_ptr_type " << id (name) << "_;";
-        }
-        else
-        {
-          os << "typedef XML_XSC_SMART_PTR( " << type << ") " << id (name) << "_auto_ptr_type;";
-          os << id (name) << "_auto_ptr_type " << id (name) << "_;";
+          case CPPMODE::CPP03:
+            os << "typedef XML_XSC_SMART_PTR( " << type << ") " << id (name) << "_auto_ptr_type;";
+            os << id (name) << "_auto_ptr_type " << id (name) << "_;";
+            break;
+          case CPPMODE::CPP11:
+          case CPPMODE::CPP17:
+            os << "using " << id (name) << "_unique_ptr_type = std::unique_ptr< " << type << ">;";
+            os << id (name) << "_unique_ptr_type " << id (name) << "_;";
+            break;
         }
       }
       else
@@ -356,7 +371,7 @@ namespace
         os << "void " << id (name) << " (" << type << " const& );";
 
         //Added for IDREF case
-        if ((idref_ptr != std::string::npos) && (!this->cpp11_))
+        if ((idref_ptr != std::string::npos) && (this->cppmode_ == CPPMODE::CPP03))
         {
            os << "::XSCRT::Type* get_" << id (name) << "_ptr ( void );\n";
            os << "void set_" << id (name) << "_ptr (const " << string_type << "& idref);";
@@ -365,15 +380,17 @@ namespace
         os << endl
            << "protected:" << endl;
 
-        if (this->cpp11_)
+        switch(this->cppmode_)
         {
-          os << "using " << id (name) << "_unique_ptr_type = std::unique_ptr< " << type << ">;";
-          os << id (name) << "_unique_ptr_type " << id (name) << "_;";
-        }
-        else
-        {
-          os << "typedef XML_XSC_SMART_PTR( " << type << ") " << id (name) << "_auto_ptr_type;";
-          os << id (name) << "_auto_ptr_type " << id (name) << "_;";
+          case CPPMODE::CPP03:
+            os << "typedef XML_XSC_SMART_PTR( " << type << ") " << id (name) << "_auto_ptr_type;";
+            os << id (name) << "_auto_ptr_type " << id (name) << "_;";
+            break;
+          case CPPMODE::CPP11:
+          case CPPMODE::CPP17:
+            os << "using " << id (name) << "_unique_ptr_type = std::unique_ptr< " << type << ">;";
+            os << id (name) << "_unique_ptr_type " << id (name) << "_;";
+            break;
         }
       }
 
@@ -434,20 +451,24 @@ namespace
     {
       os << " : public ::XSCRT::Type"
          << "{"
-         << (this->cpp11_ ? "using Base = ::XSCRT::Type;" : "typedef ::XSCRT::Type Base;" )
+         << (this->cppmode_ != CPPMODE::CPP03 ? "using Base = ::XSCRT::Type;" : "typedef ::XSCRT::Type Base;" )
          << endl;
-      if (!this->cpp11_)
+      switch(this->cppmode_)
       {
-        os << "public:" << endl;
-        os << "typedef ACE_Refcounted_Auto_Ptr < " << type_name (c) << ", ACE_Null_Mutex> _ptr;";
-        os << endl;
+        case CPPMODE::CPP03:
+          os << "public:" << endl;
+          os << "typedef ACE_Refcounted_Auto_Ptr < " << type_name (c) << ", ACE_Null_Mutex> _ptr;";
+          break;
+        case CPPMODE::CPP11:
+        case CPPMODE::CPP17:
+          break;
       }
     }
 
     virtual void
     inherits_post (Type &c)
     {
-      if (!this->cpp11_)
+      if (this->cppmode_ == CPPMODE::CPP03)
       {
         os << "public:" << endl;
         os << "typedef ACE_Refcounted_Auto_Ptr < " << type_name(c) << ", ACE_Null_Mutex> _ptr;";
@@ -577,7 +598,7 @@ namespace
       os << name << "& operator= (" << name << " const& s);"
          << endl;
 
-      if (this->cpp11_)
+      if (this->cppmode_ != CPPMODE::CPP03)
       {
         os << name << " (" << name << "&&) = default;";
         os << name << "& operator= (" << name << "&&) = default;"
@@ -910,7 +931,7 @@ generate_header (Context& ctx,
   ctx.os << "#include \"ace/XML_Utils/XMLSchema/Types.hpp\"" << endl
          << "#include \"ace/XML_Utils/XMLSchema/id_map.hpp\"" << endl;
 
-  if (!ctx.cpp11())
+  if (ctx.cppmode() == Context::CPPMODE::CPP03)
   {
     ctx.os << "#include \"ace/Refcounted_Auto_Ptr.h\"" << endl
           << "#include \"ace/Null_Mutex.h\"" << endl;
@@ -929,13 +950,13 @@ generate_header (Context& ctx,
     ctx.os << "#include \"XMLSchema/CDR_Types.hpp\"" << endl
            << "#include \"XMLSchema/id_map.hpp\"" << endl
            << endl;
-    if (!ctx.cpp11())
+    if (ctx.cppmode() == Context::CPPMODE::CPP03)
     {
       ctx.os << "#include \"ace/TSS_T.h\""<< endl;
     }
   }
 
-  if (ctx.cpp11())
+  if (ctx.cppmode() != Context::CPPMODE::CPP03)
   {
     ctx.os << "#include \"tao/x11/base/stddef.h\"" << endl;
   }
@@ -946,7 +967,7 @@ generate_header (Context& ctx,
   Includes includes (ctx);
   Traversal::Names schema_names;
 
-  if (!ctx.cpp11())
+  if (ctx.cppmode() == Context::CPPMODE::CPP03)
   {
     ctx.os << "#if !defined(XML_XSC_SMART_PTR)" << endl
            << "# if defined(ACE_HAS_CPP11)" << endl

--- a/XSC/be/CXX/Inline.cpp
+++ b/XSC/be/CXX/Inline.cpp
@@ -55,7 +55,7 @@ namespace
            << name << "_p () const"
            << "{";
 
-        if (this->cpp11_)
+        if (this->cppmode_ != CPPMODE::CPP03)
         {
           os << "return !!" << id (name) << "_;";
         }
@@ -74,7 +74,7 @@ namespace
            << "}";
 
         // Return referenced item if an IDREF
-        if ((idref_ptr != std::string::npos) && (!this->cpp11_))
+        if ((idref_ptr != std::string::npos) && (this->cppmode_ == CPPMODE::CPP03))
         {
            os << i
               << "::XSCRT::Type* " << scope << "::get_"
@@ -106,7 +106,7 @@ namespace
            << id (name) << " (" << type << " const& e)"
            << "{";
 
-        if (this->cpp11_)
+        if (this->cppmode_ != CPPMODE::CPP03)
         {
           os << "if (" << id (name) << "_)";
         }
@@ -121,14 +121,16 @@ namespace
            << "else"
            << "{";
 
-        if (this->cpp11_)
-        {
-          os << id (name) << "_ = std::make_unique< " << type << "> (e);";
-        }
-        else
-        {
-          os << id (name) << "_ = " << scope << "::" << id(name) << "_auto_ptr_type (new " << type << " (e));"
-             << id (name) << "_->container (this);";
+          switch(this->cppmode_)
+          {
+            case CPPMODE::CPP03:
+              os << id (name) << "_ = " << scope << "::" << id(name) << "_auto_ptr_type (new " << type << " (e));"
+                << id (name) << "_->container (this);";
+              break;
+            case CPPMODE::CPP11:
+            case CPPMODE::CPP17:
+              os << id (name) << "_ = std::make_unique< " << type << "> (e);";
+              break;
         }
         os << "}"
            << "}";
@@ -151,7 +153,7 @@ namespace
            << "return *" << id (name) << "_;"
            << "}";
         */
-        if ((idref_ptr != std::string::npos) && (!this->cpp11_))
+        if ((idref_ptr != std::string::npos) && (this->cppmode_ == CPPMODE::CPP03))
         {
            os << i
               << "::XSCRT::Type* " << scope << "::get_"
@@ -183,7 +185,7 @@ namespace
         // sequence
         //
 
-        if (!this->cpp11_)
+        if (this->cppmode_ == CPPMODE::CPP03)
         {
           // begin_typename
           //
@@ -210,7 +212,7 @@ namespace
            << "begin_" << name << " () const"
            << "{";
 
-        if (this->cpp11_)
+        if (this->cppmode_ != CPPMODE::CPP03)
         {
           os << "return " << id(name) << "_.cbegin ();";
         }
@@ -226,7 +228,7 @@ namespace
            << "end_" << name << " () const"
            << "{";
 
-        if (this->cpp11_)
+        if (this->cppmode_ != CPPMODE::CPP03)
         {
            os << "return " << id(name) << "_.cend ();";
         }
@@ -237,7 +239,7 @@ namespace
         os << "}";
 
         // add IDREF access method
-        if ((idref_ptr != std::string::npos) && (!this->cpp11_))
+        if ((idref_ptr != std::string::npos) && (this->cppmode_ == CPPMODE::CPP03))
         {
            os << i
               << "XSCRT::Type* " << scope << "::get_" << name
@@ -255,7 +257,7 @@ namespace
               << "}\n";
         }
 
-        if (!this->cpp11_)
+        if (this->cppmode_ == CPPMODE::CPP03)
         {
           // add_typename
           os << i
@@ -263,8 +265,8 @@ namespace
             << "add_" << name << " (" << scope << "::" << name << "_value_type const& e)"
             << "{";
           os << id(name) << "_.push_back (e);";
-          os << "}\n";
-          // add_typename
+          os << "}";
+          // del_typename
           os << i
             << "void " << scope << "::" << endl
             << "del_" << name << " (" << scope << "::" << name << "_value_type const& e)"
@@ -302,7 +304,7 @@ namespace
 
       if (a.optional ())
       {
-        if (this->cpp11_)
+        if (this->cppmode_ != CPPMODE::CPP03)
         {
           os << i
             << "bool " << scope << "::" << endl
@@ -336,7 +338,7 @@ namespace
            << "}";
 
         // Return a pointer to the referenced item
-        if ((idref_ptr != std::string::npos) && (!this->cpp11_))
+        if ((idref_ptr != std::string::npos) && (this->cppmode_ == CPPMODE::CPP03))
         {
            os << i
               << "::XSCRT::Type* " << scope << "::get_"
@@ -361,7 +363,7 @@ namespace
            << id (name) << " (" << type << " const& e)"
            << "{";
 
-        if (this->cpp11_)
+        if (this->cppmode_ != CPPMODE::CPP03)
         {
           os << "if (" << id (name) << "_)";
         }
@@ -376,7 +378,7 @@ namespace
            << "else"
            << "{";
 
-        if (this->cpp11_)
+        if (this->cppmode_ != CPPMODE::CPP03)
         {
           os << id (name) << "_ = std::make_unique< " << type << "> (e);";
         }
@@ -404,8 +406,8 @@ namespace
            << "return *" << id (name) << "_;"
            << "}";
 
-        //Return a pointer to the referenced item
-        if ((idref_ptr != std::string::npos) && (!this->cpp11_))
+        // Return a pointer to the referenced item
+        if ((idref_ptr != std::string::npos) && (this->cppmode_ == CPPMODE::CPP03))
         {
            os << i
               << "::XSCRT::Type* " << scope << "::get_"
@@ -630,7 +632,7 @@ namespace
       os << "}";
 
       std::wstring selfcheck;
-      if (this->cpp11_)
+      if (this->cppmode_ != CPPMODE::CPP03)
       {
         selfcheck = L"if (std::addressof(s) != this)";
       }
@@ -855,7 +857,7 @@ namespace
           string name (id (e.name ()));
           string type (type_name (e));
 
-          if (this->cpp11_)
+          if (this->cppmode_ != CPPMODE::CPP03)
           {
             os << ", " << name << "_ (std::make_unique< " << type << "> (" << name << "__))" << endl;
           }
@@ -887,7 +889,7 @@ namespace
           string name (id (a.name ()));
           string type (type_name (a));
 
-          if (this->cpp11_)
+          if (this->cppmode_ != CPPMODE::CPP03)
           {
             os << ", " << name << "_ (std::make_unique< " << type << "> (" << name << "__))" << endl;
           }
@@ -915,7 +917,7 @@ namespace
       virtual void
       traverse (SemanticGraph::Element& e)
       {
-        if (e.min () == 1 && e.max () == 1 && !this->cpp11_)
+        if (e.min () == 1 && e.max () == 1 && (this->cppmode_ == CPPMODE::CPP03))
         {
           // one
           //
@@ -926,7 +928,7 @@ namespace
       virtual void
       traverse (SemanticGraph::Attribute& a)
       {
-        if (!a.optional () && !this->cpp11_)
+        if (!a.optional () && (this->cppmode_ == CPPMODE::CPP03))
         {
           os << id (a.name ()) << "_->container (this);";
         }
@@ -962,7 +964,7 @@ namespace
         string name (id (e.name ()));
         string type (type_name (e));
         std::wstring nullptr_string;
-        if (this->cpp11_)
+        if (this->cppmode_ != CPPMODE::CPP03)
         {
           nullptr_string = L"nullptr";
         }
@@ -982,7 +984,7 @@ namespace
           {
             // optional
             //
-            if (this->cpp11_)
+            if (this->cppmode_ != CPPMODE::CPP03)
             {
               os << ", " << name << "_ ("
                 << "s." << name << "_ ? "
@@ -999,7 +1001,7 @@ namespace
           {
             // one
             //
-            if (this->cpp11_)
+            if (this->cppmode_ != CPPMODE::CPP03)
             {
               os << ", " << name << "_ (std::make_unique< " << type << "> (*s." << name << "_))" << endl;
             }
@@ -1023,7 +1025,7 @@ namespace
         string name (id (a.name ()));
         string type (type_name (a));
         std::wstring nullptr_string;
-        if (this->cpp11_)
+        if (this->cppmode_ != CPPMODE::CPP03)
         {
           nullptr_string = L"nullptr";
         }
@@ -1034,7 +1036,7 @@ namespace
 
         if (a.optional ())
         {
-          if (this->cpp11_)
+          if (this->cppmode_ != CPPMODE::CPP03)
           {
             os << ", " << name << "_ ("
               << "s." << name << "_ ? "
@@ -1049,7 +1051,7 @@ namespace
         }
         else
         {
-          if (this->cpp11_)
+          if (this->cppmode_ != CPPMODE::CPP03)
           {
             os << ", " << name << "_ (std::make_unique< " << type << "> (*s." << name << "_))" << endl;
           }
@@ -1089,13 +1091,13 @@ namespace
 
           // optional
           //
-          if (!this->cpp11_)
+          if (this->cppmode_ == CPPMODE::CPP03)
           {
             os << "if (" << name << "_.get ()) "
                << name << "_->container (this);";
           }
         }
-        else if (e.min () == 1 && e.max () == 1 && !this->cpp11_)
+        else if (e.min () == 1 && e.max () == 1 && this->cppmode_ == CPPMODE::CPP03)
         {
           os << id (name) << "_->container (this);";
         }
@@ -1126,7 +1128,7 @@ namespace
         {
           // optional
           //
-          if (!this->cpp11_)
+          if (this->cppmode_ == CPPMODE::CPP03)
           {
             os << "if (" << name << "_.get ()) "
                << name << "_->container (this);";
@@ -1134,7 +1136,7 @@ namespace
         }
         else
         {
-          if (!this->cpp11_)
+          if (this->cppmode_ == CPPMODE::CPP03)
           {
             os << name << "_->container (this);";
           }
@@ -1172,7 +1174,7 @@ namespace
 
           // optional
           //
-          if (this->cpp11_)
+          if (this->cppmode_ != CPPMODE::CPP03)
           {
             os << "if (s." << name << "_)" << std::endl
                << "  " << name << " (*(s." << name << "_));"
@@ -1229,7 +1231,7 @@ namespace
 
         if (a.optional ())
         {
-          if (this->cpp11_)
+          if (this->cppmode_ != CPPMODE::CPP03)
           {
             os << "if (s." << name << "_) "
               << name << " (*(s." << name << "_));"
@@ -1409,7 +1411,7 @@ generate_inline (Context& ctx, SemanticGraph::Schema& schema, bool i)
     ctx.os << "#include \"ace/ace_wchar.h\"" << endl;
   }
 
-  if (!ctx.cpp11 ())
+  if (ctx.cppmode() == Context::CPPMODE::CPP03)
   {
     ctx.os << "#include \"ace/Null_Mutex.h\"" << endl
       << "#include \"ace/TSS_T.h\""<< endl

--- a/XSC/be/CXX/ParserSource.cpp
+++ b/XSC/be/CXX/ParserSource.cpp
@@ -42,7 +42,7 @@ namespace
          << id (name) << " (xercesc::DOMDocument const* d)"
          << "{";
 
-      if (!this->cpp11_)
+      if (this->cppmode_ == CPPMODE::CPP03)
       {
          os << "// Initiate our Singleton as an ACE_TSS object (ensures thread" << endl
             << "// specific storage" << endl
@@ -59,7 +59,7 @@ namespace
          << "{"
          << type << " r (e);\n";
 
-     if (!this->cpp11_)
+     if (this->cppmode_ == CPPMODE::CPP03)
      {
        os  << "(*TSS_ID_Map)->resolve_idref();" << endl;
      }

--- a/XSC/be/CXX/Source.cpp
+++ b/XSC/be/CXX/Source.cpp
@@ -62,7 +62,7 @@ namespace
       {
         // sequence
         //
-        if (this->cpp11_)
+        if (this->cppmode_ != CPPMODE::CPP03)
         {
           os << type << " t (e);";
           os << id (name) << "_.push_back (t);";
@@ -85,7 +85,7 @@ namespace
       {
         // one
         //
-        if (this->cpp11_)
+        if (this->cppmode_ != CPPMODE::CPP03)
         {
           os << id (name) << "_ = std::make_unique< " << type << "> (e);";
         }
@@ -104,7 +104,7 @@ namespace
       std::string::size_type idref_ptr = type.find(idref_str);
       std::string::size_type id_ptr = type.find(id_str);
 
-      if ((idref_ptr != std::string::npos) && (!this->cpp11_))
+      if ((idref_ptr != std::string::npos) && (this->cppmode_ == CPPMODE::CPP03))
       {
         if (c.max() != 1)
         {
@@ -152,7 +152,7 @@ namespace
              //<< id(name) << "_).id().c_str(), dynamic_cast<XSCRT::Type*> (this));\n";
         }
       }
-      else if ((id_ptr != std::string::npos) && (!this->cpp11_))
+      else if ((id_ptr != std::string::npos) && (this->cppmode_ == CPPMODE::CPP03))
       {
         if (c.max() == 1)
         {
@@ -225,7 +225,7 @@ namespace
       }
       else
       {
-        if (this->cpp11_)
+        if (this->cppmode_ != CPPMODE::CPP03)
         {
           os << id (name) << "_ = std::make_unique<" << type << "> (a);";
         }
@@ -246,7 +246,7 @@ namespace
       idref_ptr = type.find(idref_str);
       id_ptr = type.find(id_str);
 
-      if ((idref_ptr != std::string::npos) && (!this->cpp11_))
+      if ((idref_ptr != std::string::npos) && (this->cppmode_ == CPPMODE::CPP03))
       {
         if (this->char_type == char_compare)
         {
@@ -276,7 +276,7 @@ namespace
         //"_).id(), dynamic_cast<XSCRT::Type*> (this));\n";
       }
       */
-      else if ((id_ptr != std::string::npos) && (!this->cpp11_))
+      else if ((id_ptr != std::string::npos) && (this->cppmode_ == CPPMODE::CPP03))
       {
         if (this->char_type == char_compare)
         {

--- a/XSC/be/CXX/TraversalHeader.cpp
+++ b/XSC/be/CXX/TraversalHeader.cpp
@@ -258,7 +258,7 @@ namespace
     virtual void
     pre (Type& c)
     {
-      string override_string (this->cpp11_ ? L" override" : L"");
+      string override_string (this->cppmode_ != CPPMODE::CPP03 ? L" override" : L"");
 
       os << "struct " << e << name_
          << " : ::XMLSchema::Traversal::Traverser< " << fq_name (c) << " >"
@@ -327,7 +327,7 @@ namespace
       string name ((this->name_ != L"") ? name_: id (e.name ()));
       string type (type_name (e));
 
-      if (this->cpp11_)
+      if (this->cppmode_ != CPPMODE::CPP03)
       {
         os << "using " << name << " = ::XMLSchema::Traversal::Traverser< " << type << ">;" << endl;
       }

--- a/XSC/be/CXX/WriterHeader.cpp
+++ b/XSC/be/CXX/WriterHeader.cpp
@@ -39,7 +39,7 @@ namespace
 
       if (e.min () == 0 && e.max () == 1)
       {
-        if (!this->cpp11_)
+        if (this->cppmode_ == CPPMODE::CPP03)
         {
           // Borland post
           os << "virtual void" << endl
@@ -58,7 +58,7 @@ namespace
       }
       else if (e.min () == 1 && e.max () == 1)
       {
-        if (!this->cpp11_)
+        if (this->cppmode_ == CPPMODE::CPP03)
         {
           // Borland post
           os << "virtual void" << endl
@@ -82,7 +82,7 @@ namespace
 
         // Pre
         //
-        if (!this->cpp11_)
+        if (this->cppmode_ == CPPMODE::CPP03)
         {
           os << "virtual void" << endl
             << name << "_pre (Type &o)" << endl
@@ -100,7 +100,7 @@ namespace
 
         // non-const next
         //
-        if (!this->cpp11_)
+        if (this->cppmode_ == CPPMODE::CPP03)
         {
           os << "virtual void" << endl
             << name << "_next (Type &o)" << endl
@@ -117,7 +117,7 @@ namespace
            << endl;
 
         //  post
-        if (!this->cpp11_)
+        if (this->cppmode_ == CPPMODE::CPP03)
         {
           os << "virtual void" << endl
             << name << "_post (Type &o)" << endl
@@ -146,7 +146,7 @@ namespace
       string name (a.name ());
 
       // Borland post
-      if (!this->cpp11_)
+      if (this->cppmode_ == CPPMODE::CPP03)
       {
         os << "virtual void" << endl
           << id (name)  << " (Type &o)" << endl
@@ -255,7 +255,7 @@ namespace
 
       //@@ Should probably be Type__
       //
-      if (this->cpp11_)
+      if (this->cppmode_ != CPPMODE::CPP03)
       {
         os << "using Type =" << fq_name (c) << ";";
       }
@@ -270,7 +270,7 @@ namespace
          << endl;
 
       // Non-const traverse for Borland
-      if (!this->cpp11_)
+      if (this->cppmode_ == CPPMODE::CPP03)
       {
         os << "virtual void" << endl
           << "traverse (Type &o)" << endl
@@ -280,7 +280,7 @@ namespace
           << "}";
       }
 
-      string override_string (this->cpp11_ ? L" override" : L"");
+      string override_string (this->cppmode_ != CPPMODE::CPP03 ? L" override" : L"");
 
       // traverse
       //
@@ -292,7 +292,7 @@ namespace
     virtual void
     post (Type& )
     {
-      string default_string (this->cpp11_ ? L" = default" : L"");
+      string default_string (this->cppmode_ != CPPMODE::CPP03 ? L" = default" : L"");
       os << "protected:" << endl
          << name_ << " ()" << default_string << ";"
          <<"};";
@@ -323,8 +323,8 @@ namespace
     {
       string name ((this->name_ != L"") ? name_ : id (e.name ()));
       string type (type_name (e));
-      string override_string (this->cpp11_ ? L" override" : L"");
-      string default_string (this->cpp11_ ? L" = default" : L"");
+      string override_string (this->cppmode_ != CPPMODE::CPP03 ? L" override" : L"");
+      string default_string (this->cppmode_ != CPPMODE::CPP03 ? L" = default" : L"");
 
       if (name == L"") name = L"BAD NAME";
 
@@ -338,7 +338,7 @@ namespace
          << endl;
 
       // Non-const traverse for Borland
-      if (!this->cpp11_)
+      if (this->cppmode_ == CPPMODE::CPP03)
       {
         os << "virtual void" << endl
           << "traverse (Type &o)"

--- a/XSC/be/CXX/WriterSource.cpp
+++ b/XSC/be/CXX/WriterSource.cpp
@@ -103,7 +103,7 @@ namespace
       //string scope (id (a.scope ().name ()));
       string ns (xs_ns_name (a));
       std::wstring attrinit;
-      if (this->cpp11_)
+      if (this->cppmode_ != CPPMODE::CPP03)
       {
         attrinit = L"attr_ (std::addressof(a));";
       }
@@ -124,7 +124,7 @@ namespace
          << attrinit
          << "Traversal::" << scope << "::" << id (name) << " (o);";
 
-      if (this->cpp11_)
+      if (this->cppmode_ != CPPMODE::CPP03)
       {
         os << "attr_ (nullptr);";
       }
@@ -241,7 +241,7 @@ namespace
 
       // c-tor ()
       //
-      if (!this->cpp11_)
+      if (this->cppmode_ == CPPMODE::CPP03)
       {
         os << scope << "::" << endl
           << name << " ()"
@@ -320,7 +320,7 @@ namespace
 
       // c-tor ()
       //
-      if (!this->cpp11_)
+      if (this->cppmode_ == CPPMODE::CPP03)
       {
         os << name << "::" << endl
           << name << " ()"


### PR DESCRIPTION
    * XSC/be/CXX/Elements.hpp:
    * XSC/be/CXX/Generator.cpp:
    * XSC/be/CXX/Header.cpp:
    * XSC/be/CXX/Inline.cpp:
    * XSC/be/CXX/ParserSource.cpp:
    * XSC/be/CXX/Source.cpp:
    * XSC/be/CXX/TraversalHeader.cpp:
    * XSC/be/CXX/WriterHeader.cpp:
    * XSC/be/CXX/WriterSource.cpp: